### PR TITLE
Add pipeline support and some aioredis sugar

### DIFF
--- a/mockaioredis/__init__.py
+++ b/mockaioredis/__init__.py
@@ -1,4 +1,4 @@
 from .commands import MockRedis, create_redis
-from .pool import MockRedisPool, create_pool
+from .pool import MockRedisPool, create_pool, create_redis_pool
 
-__version__ = '0.0.10'
+__version__ = '0.0.11'

--- a/mockaioredis/commands/__init__.py
+++ b/mockaioredis/commands/__init__.py
@@ -6,8 +6,9 @@ from .list import ListCommandsMixin
 
 __all__ = ['MockRedis']
 
+
 class MockRedis(GenericCommandsMixin, HashCommandsMixin, ListCommandsMixin):
-    '''Fake high-level aioredis.Redis interface'''
+    """Fake high-level aioredis.Redis interface"""
 
     def __init__(self, connection=None, encoding=None):
         # Just for API compatibility

--- a/mockaioredis/commands/generic.py
+++ b/mockaioredis/commands/generic.py
@@ -92,9 +92,14 @@ class GenericCommandsMixin:
 
         return list(map(lambda x: x.decode(encoding), ret))
 
-    async def set(self, key, value, ex=None, px=None, nx=False, xx=False):
-        '''Sets the value of a key'''
-        return self._redis.set(key, value, ex=ex, px=px, nx=nx, xx=xx)
+    async def set(self, key, value, *, expire=None, pexpire=None, exist=None):
+        """Sets the value of a key"""
+        nx = xx = False
+        if exist is self.SET_IF_EXIST:
+            xx = True
+        elif exist is self.SET_IF_NOT_EXIST:
+            nx = True
+        return self._redis.set(key, value, ex=expire, px=pexpire, nx=nx, xx=xx)
 
     async def ttl(self, key):
         """Return the TTL of a key in seconds"""

--- a/tests/test_geneic.py
+++ b/tests/test_geneic.py
@@ -1,5 +1,6 @@
 import pytest
 
+
 @pytest.mark.asyncio
 async def test_exists(redis):
     redis._redis.set('foo', 'bar')
@@ -104,3 +105,12 @@ async def test_ttl(redis):
     redis._redis.setex('foo', 'bar', 30)
     ret = await redis.ttl('foo')
     assert ret <= 30
+
+
+@pytest.mark.asyncio
+async def test_pipeline(redis):
+    pipe = redis.pipeline()
+    pipe.set('foo', 'bar')
+    pipe.get('foo')
+    ret = await pipe.execute()
+    assert [True, b'bar'] == ret


### PR DESCRIPTION
This PR adds support for pipelines. I also added a `create_redis_pool` to mimic the one in aioredis and modified the set command to make it exactly like the one in aioredis too