### PR TITLE
Deprecate loop argument.

### DIFF
--- a/mockaioredis/pool.py
+++ b/mockaioredis/pool.py
@@ -1,6 +1,8 @@
 'Fake aioredis.RedisPool and related functions'
 import asyncio
 import collections
+import sys
+import warnings
 
 from .commands import MockRedis, create_redis
 from .util import _NOTSET
@@ -52,7 +54,10 @@ class MockRedisPool:
 
     def __init__(self, address, db=0, password=0, encoding=None,
                  *, minsize, maxsize, commands_factory, ssl=None, loop=None):
-        if loop is None:
+        if loop is not None and sys.version_info >= (3, 8):
+            warnings.warn("The loop argument is deprecated",
+                          DeprecationWarning)
+        if loop is None and sys.version_info < (3, 8):
             loop = asyncio.get_event_loop()
 
         self._address = address


### PR DESCRIPTION
The loop argument for all stdlib asyncio methods has been deprecated in python 3.8.

It has also been deprecated in aioredis (https://github.com/aio-libs/aioredis/pull/666/files)

This change:

1.  Deprecates the loop argument in mockaioredis if using >= python 3.8
2.  Only set the loop var = get_event_loop if < python 3.8. This is so that you don't get DeprecationWarnings from stdlib asyncio methods.