### PR TITLE
Added possibility to test redis when used with "with await pool"

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ If you want to update an existing install, run `pip install --update mockaioredi
 You can also clone this repository from github and run `pip install .` from the repository base directory.
 
 
+Usage
+-----
+
+You can use it as a fixture using pytest-mock
+
+```python
+import mockaioredis
+
+@pytest.fixture(autouse=True)
+def redis(mocker):
+    """Mock Redis."""
+    mocker.patch.object(aioredis, 'create_pool', new=mockaioredis.create_pool)
+```
+
+
 License
 -------
 Like mockredispy, mockaioredis is licensed under the Apache License, Version 2.0.

--- a/mockaioredis/__init__.py
+++ b/mockaioredis/__init__.py
@@ -1,4 +1,4 @@
 from .commands import MockRedis, create_redis
 from .pool import MockRedisPool, create_pool, create_redis_pool
 
-__version__ = '0.0.14'
+__version__ = '0.0.15'


### PR DESCRIPTION
Hello,

I have extended the functionality to allow tests when redis is used usign "with await pool" sentence.